### PR TITLE
don't crash on a fail connection attempt 

### DIFF
--- a/mongeese.js
+++ b/mongeese.js
@@ -37,6 +37,9 @@ module.exports = mongeese = {
   createConnection: function (name, uri, options) {
     if (name !== undefined) {
       mongeese.connections[name] = mongoose.createConnection(uri || 'mongodb://localhost/test', options || {});
+      mongeese.connections[name].on('error', function(err){
+        console.log('Could not connect to uri:', uri);
+      });
       return mongeese.connections[name];
     } else { throw new Error('Connection name required.'); }
   },


### PR DESCRIPTION
In the event that there is no 'localhost' MongoDB running, mongeese will cause an app to crash if the default uri is used to create a connection with mongoose -- so if that happens, handle the error to avoid a crash